### PR TITLE
Use new format of thread timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your `Notifiable` classes you should add a method named `routeNotificationFor
 API token, an optionally the channel name
 
 ```php
-public function routeNotificationForSlackApi()
+public function routeNotificationForInteractiveSlack()
 {
     return [
         'token' => 'xoxp-slack-token',

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ composer require spatie/interactive-slack-notification-channel
 
 ## Usage
 
-In your `Notifiable` classes you should add a method named `routeNotificationForSlackApi` that returns an array with the
+In your `Notifiable` classes you should add a method named `routeNotificationForInteractiveSlack` that returns an array with the
 API token, an optionally the channel name
 
 ```php

--- a/src/Channels/InteractiveSlackChannel.php
+++ b/src/Channels/InteractiveSlackChannel.php
@@ -58,9 +58,8 @@ class InteractiveSlackChannel
             ], $optionalFields),
         ];
 
-
         $payload['headers'] = [
-            'Content-type' => 'application/json',
+            'Content-Type' => 'application/json; charset=UTF-8',
             'Authorization' => 'Bearer ' . $this->token,
         ];
 

--- a/src/Channels/InteractiveSlackChannel.php
+++ b/src/Channels/InteractiveSlackChannel.php
@@ -31,6 +31,10 @@ class InteractiveSlackChannel
         $response = Http::withHeaders($payload['headers'])->post(self::API_ENDPOINT, $payload['json']);
 
         if (method_exists($notification, 'interactiveSlackResponse')) {
+            if (($response->json('ok')) !== true) {
+                throw new \RuntimeException('Unexpected response from Slack: '.$response->body());
+            }
+
             return $notification->interactiveSlackResponse($response->json() ?? []);
         }
 

--- a/src/Messages/SlackMessage.php
+++ b/src/Messages/SlackMessage.php
@@ -147,7 +147,7 @@ class SlackMessage
         return $this;
     }
 
-    public function threadTimestamp(DateTimeInterface | DateInterval | int $threadTimestamp): self
+    public function threadTimestamp(string $threadTimestamp): self
     {
         $this->threadTimestamp = $threadTimestamp;
 


### PR DESCRIPTION
Related issue: #2 

The version from `master` branch doesn't work on my end, I found slack uses `float` format for timestamp (probably a new format), so I've applied some minimal changes to make this package work.
________________

PS: Why not `float` type?
> would it be fixed by also allowing a float?

Because float operations may be not safe